### PR TITLE
Enhance/rake tasks force suffix

### DIFF
--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -59,7 +59,7 @@ module Chewy
       # @param parallel [true, Integer, Hash] any acceptable parallel options for import
       # @param output [IO] output io for logging
       # @return [Array<Chewy::Index>] indexes that were actually reset
-      def upgrade(only: nil, except: nil, parallel: nil, output: STDOUT)
+      def upgrade(only: nil, except: nil, parallel: nil, output: STDOUT, force_suffix: nil)
         subscribed_task_stats(output) do
           indexes = indexes_from(only: only, except: except)
 
@@ -70,7 +70,7 @@ module Chewy
           if changed_indexes.present?
             indexes.each do |index|
               if changed_indexes.include?(index)
-                reset_one(index, output, parallel: parallel)
+                reset_one(index, output, parallel: parallel, force_suffix: force_suffix)
               else
                 output.puts "Skipping #{index}, the specification didn't change"
               end
@@ -294,9 +294,10 @@ module Chewy
         end.compact.reverse.join(' ')
       end
 
-      def reset_one(index, output, parallel: false)
+      def reset_one(index, output, parallel: false, force_suffix:)
         output.puts "Resetting #{index}"
-        index.reset!((Time.now.to_f * 1000).round, parallel: parallel)
+        suffix = force_suffix || (Time.now.to_f * 1000).round
+        index.reset!(suffix, parallel: parallel)
       end
     end
   end

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -294,7 +294,7 @@ module Chewy
         end.compact.reverse.join(' ')
       end
 
-      def reset_one(index, output, parallel: false, force_suffix:)
+      def reset_one(index, output, parallel: false, force_suffix: nil)
         output.puts "Resetting #{index}"
         suffix = force_suffix || (Time.now.to_f * 1000).round
         index.reset!(suffix, parallel: parallel)

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -28,7 +28,8 @@ namespace :chewy do
 
   desc 'Resets data for the specified indexes or all of them only if the index specification is changed'
   task upgrade: :environment do |_task, args|
-    Chewy::RakeHelper.upgrade(parse_classes(args.extras))
+    force_suffix = args.extras.first
+    Chewy::RakeHelper.upgrade(force_suffix: force_suffix)
   end
 
   desc 'Updates data for the specified indexes/types or all of them'
@@ -56,7 +57,9 @@ namespace :chewy do
 
     desc 'Parallel version of `rake chewy:upgrade`'
     task upgrade: :environment do |_task, args|
-      Chewy::RakeHelper.upgrade(parse_parallel_args(args.extras))
+      parallel = args.extras.first =~ /\A\d+\z/ ? Integer(args.extras.first) : true
+      force_suffix = args.extras.second
+      Chewy::RakeHelper.upgrade(parallel: parallel, force_suffix: force_suffix)
     end
 
     desc 'Parallel version of `rake chewy:update`'

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -42,8 +42,9 @@ namespace :chewy do
   end
 
   desc 'Resets all the indexes with the specification changed and synchronizes the rest of them'
-  task deploy: :environment do
-    processed = Chewy::RakeHelper.upgrade
+  task deploy: :environment do |_task, args|
+    force_suffix = args.extras.first
+    processed = Chewy::RakeHelper.upgrade(force_suffix: force_suffix)
     Chewy::RakeHelper.sync(except: processed)
   end
 
@@ -71,7 +72,8 @@ namespace :chewy do
     desc 'Parallel version of `rake chewy:deploy`'
     task deploy: :environment do |_task, args|
       parallel = args.extras.first =~ /\A\d+\z/ ? Integer(args.extras.first) : true
-      processed = Chewy::RakeHelper.upgrade(parallel: parallel)
+      force_suffix = args.extras.second
+      processed = Chewy::RakeHelper.upgrade(parallel: parallel, force_suffix: force_suffix)
       Chewy::RakeHelper.sync(except: processed, parallel: parallel)
     end
   end


### PR DESCRIPTION
### :pushpin: References
* **Issue / Jira ticket:** [CNF|TECH - ElasticSearch Integration](https://badiapp.atlassian.net/wiki/spaces/TECH/pages/277119206/ElasticSearch+Integration)
* **Related pull-requests:** [core-api#1148](https://github.com/Badiapp/badi-api/pull/1148)
* **Related eng doc:** -

### :dart: What is the goal?

To be able to set a custom suffix to ElasticSearch indices through Chewy's rake upgrade task.

More context in the links above.

### :memo: How is it being implemented?

Chewy upgrade task is extended to accept a new parameter, an index suffix. If no index suffix is provided, the index is created with a timestamp suffix.

```
bundle exec rake chewy:upgrade[my_index_suffix]
```

### :thinking: Are there any DB-related changes?

Nope

### :gem: New gems?

Nope
